### PR TITLE
feat: add tab context menu for code-editor

### DIFF
--- a/packages/code-editor/src/CodeEditorCollection.js
+++ b/packages/code-editor/src/CodeEditorCollection.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-
+import platform from '@obsidians/platform'
 import { Tabs } from '@obsidians/ui-components'
 import fileOps from '@obsidians/file-ops'
 
@@ -30,21 +30,21 @@ export default class CodeEditorCollection extends PureComponent {
       },
       {
         text: 'Close Others',
-        onClick: () => {}
+        onClick: this.closeOtherFiles
       },
       {
         text: 'Close All',
         onClick: this.closeAll
       },
+      null,
       {
         text: 'Copy Path',
-        onClick: () => {}
+        onClick: this.copyPath
       },
-      ,
-      {
+      ...platform.isDesktop ? [{
         text: 'Reveal In Finder',
-        onClick: () => {}
-      }
+        onClick: this.showInFinder
+      }] : []
     ]
   }
 
@@ -65,6 +65,14 @@ export default class CodeEditorCollection extends PureComponent {
     this.tabs.current.updateTab({ unsaved })
   }
 
+  showInFinder = tab => {
+    fileOps.current.showItemInFolder(tab.path)
+  }
+
+  // TODO
+  copyPath = tab => {
+  }
+
   allUnsavedFiles = () => this.tabs.current.allTabs
     .filter(({ path, unsaved }) => path && unsaved)
     .map(({ path }) => path);
@@ -82,6 +90,16 @@ export default class CodeEditorCollection extends PureComponent {
   closeCurrentFile = () => {
     const { onCloseTab, currentTab } = this.tabs.current
     onCloseTab(currentTab)
+  }
+
+  // MARK: may can define a batch delete in the Tabs component
+  closeOtherFiles = () => {
+    const { onCloseTab, currentTab, allTabs } = this.tabs.current;
+    const shouldCloseTabs = allTabs.filter(tab => tab.key !== currentTab.key);
+
+    shouldCloseTabs.forEach(tab => {
+      onCloseTab(tab)
+    })
   }
 
   saveFile = async filePath => await modelSessionManager.saveFile(filePath)

--- a/packages/code-editor/src/CodeEditorCollection.js
+++ b/packages/code-editor/src/CodeEditorCollection.js
@@ -23,6 +23,29 @@ export default class CodeEditorCollection extends PureComponent {
     modelSessionManager.editorContainer = this
     this.tabs = React.createRef()
     this.editorContainer = React.createRef()
+    this.tabContextMenu = [
+      {
+        text: 'Close',
+        onClick: this.closeCurrentFile
+      },
+      {
+        text: 'Close Others',
+        onClick: () => {}
+      },
+      {
+        text: 'Close All',
+        onClick: this.closeAll
+      },
+      {
+        text: 'Copy Path',
+        onClick: () => {}
+      },
+      ,
+      {
+        text: 'Reveal In Finder',
+        onClick: () => {}
+      }
+    ]
   }
 
   refresh () {
@@ -166,13 +189,15 @@ export default class CodeEditorCollection extends PureComponent {
       <div className='d-flex w-100 h-100 overflow-hidden bg2'>
         <Tabs
           ref={this.tabs}
-          size='sm'
+          size='xl'
+          asd='1'
           headerClassName='nav-tabs-dark-active'
           initialSelected={initialTab}
           onSelectTab={this.onSelectTab}
           tryCloseTab={this.tryCloseTab}
           createNewTab={() => fileOps.current.openNewFile(projectRoot)}
           getTabText={tab => modelSessionManager.tabTitle(tab)}
+          tabContextMenu={this.tabContextMenu}
         >
           <MonacoEditorContainer
             ref={this.editorContainer}

--- a/packages/code-editor/src/CodeEditorCollection.js
+++ b/packages/code-editor/src/CodeEditorCollection.js
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
-import platform from '@obsidians/platform'
+import platform, { ClipBoardService } from '@obsidians/platform'
 import { Tabs } from '@obsidians/ui-components'
 import fileOps from '@obsidians/file-ops'
 
@@ -42,7 +42,7 @@ export default class CodeEditorCollection extends PureComponent {
         onClick: this.copyPath
       },
       ...platform.isDesktop ? [{
-        text: 'Reveal In Finder',
+        text: 'Open Containing Folder',
         onClick: this.showInFinder
       }] : []
     ]
@@ -69,8 +69,9 @@ export default class CodeEditorCollection extends PureComponent {
     fileOps.current.showItemInFolder(tab.path)
   }
 
-  // TODO
-  copyPath = tab => {
+  copyPath = ({pathInProject}) => {
+    const clipboard = new ClipBoardService()
+    clipboard.writeText(pathInProject)
   }
 
   allUnsavedFiles = () => this.tabs.current.allTabs

--- a/packages/platform/.babelrc
+++ b/packages/platform/.babelrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "@babel/plugin-proposal-class-properties"
+  ],
+  "presets": [
+    ["@babel/preset-env", { "modules": false }]
+  ]
+}

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -4,10 +4,40 @@
   "description": "Platform related",
   "author": "Phil <qft.gtr@gmail.com>",
   "license": "GPL-3.0",
-  "main": "src/index.js",
+  "source": "src/index.js",
+  "main": "main/index.js",
+  "browser": "dist/index.es.js",
   "files": [
-    "src"
+    "dist",
+    "main"
   ],
-  "scripts": {},
-  "dependencies": {}
+  "scripts": {
+    "start": "rollup -c -w",
+    "build": "rollup -c",
+    "prepare": "yarn build"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@babel/core": "^7.16.0",
+    "@babel/plugin-proposal-class-properties": "^7.16.0",
+    "@babel/preset-env": "^7.16.4",
+    "@rollup/plugin-babel": "^5.3.0",
+    "@rollup/plugin-commonjs": "^21.0.1",
+    "@rollup/plugin-node-resolve": "^13.0.6",
+    "@rollup/plugin-url": "^6.1.0",
+    "rollup": "^2.60.2",
+    "rollup-plugin-peer-deps-external": "^2.2.4"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
 }

--- a/packages/platform/rollup.config.js
+++ b/packages/platform/rollup.config.js
@@ -1,0 +1,28 @@
+import babel from '@rollup/plugin-babel'
+import commonjs from '@rollup/plugin-commonjs'
+import external from 'rollup-plugin-peer-deps-external'
+import resolve from '@rollup/plugin-node-resolve'
+import url from '@rollup/plugin-url'
+
+import pkg from './package.json'
+
+export default {
+  input: pkg.source,
+  output: [
+    {
+      file: pkg.browser,
+      format: 'es',
+      sourcemap: true
+    }
+  ],
+  plugins: [
+    external(),
+    url(),
+    babel({ exclude: 'node_modules/**' }),
+    resolve(),
+    commonjs()
+  ],
+  watch: {
+    include: 'src/**',
+  }
+}

--- a/packages/platform/src/clipboard.js
+++ b/packages/platform/src/clipboard.js
@@ -1,0 +1,35 @@
+export default class ClipBoardService {
+	async writeText(text) {
+		// Guard access to navigator.clipboard with try/catch
+		// as we have seen DOMExceptions in certain browsers
+		// due to security policies.
+		try {
+			return await navigator.clipboard.writeText(text)
+		} catch (error) {
+			console.error(error)
+		}
+
+		// Fallback to textarea and execCommand solution
+		const activeElement = document.activeElement
+		const textAreaEle = document.createElement('textarea')
+		textAreaEle.setAttribute('aria-hidden', true)
+		
+		const textArea = document.body.appendChild(textAreaEle)
+		textArea.style.height = '1px'
+		textArea.style.width = '1px'
+		textArea.style.position = 'absolute'
+
+		textArea.value = text
+		textArea.focus()
+		textArea.select()
+		document.execCommand('copy')
+
+		if (activeElement instanceof HTMLElement) {
+			activeElement.focus()
+		}
+
+		document.body.removeChild(textArea)
+
+		return
+	}
+}

--- a/packages/platform/src/index.js
+++ b/packages/platform/src/index.js
@@ -31,3 +31,5 @@ export default {
   get os() { return os },
   get isAppleSilicon () { return appleSilicon },
 }
+
+export { default as ClipBoardService} from "./clipboard"

--- a/packages/ui-components/src/Tabs/TabContextMenu.js
+++ b/packages/ui-components/src/Tabs/TabContextMenu.js
@@ -1,0 +1,52 @@
+import React, { PureComponent } from 'react'
+import { ContextMenu, MenuItem } from 'react-contextmenu'
+
+ContextMenu.defaultProps.className = 'dropdown-menu dropdown-menu-sm show'
+MenuItem.defaultProps.className = 'dropdown-item'
+
+export default class TabContextMenu extends PureComponent {
+  renderMenuItem = (menuItem, index) => {
+    if (!menuItem) {
+      return <MenuItem key={`menu-item-${index}`} divider className='dropdown-divider' />
+    }
+
+    const onClick = event => {
+      event.stopPropagation()
+      if (menuItem.onClick) {
+        menuItem.onClick(this.props.node)
+      } else {
+        this.props.onOpen(event)
+      }
+    }
+
+    return (
+      <MenuItem
+        key={`menu-item-${index}`}
+        onClick={onClick}
+      >
+        {menuItem.text}
+      </MenuItem>
+    )
+  }
+
+  render () {
+    const { node } = this.props
+
+    let contextMenu
+    if (node.root) {
+      contextMenu = this.props.contextMenu.slice(0, -3)
+    } else {
+      contextMenu = this.props.contextMenu
+    }
+
+    if (!contextMenu || !contextMenu.length) {
+      return null
+    }
+
+    return (
+      <ContextMenu id={`${node.key}/tab-item`}>
+        {contextMenu.map(this.renderMenuItem)}
+      </ContextMenu>
+    )
+  }
+}

--- a/packages/ui-components/src/Tabs/TabHeader.js
+++ b/packages/ui-components/src/Tabs/TabHeader.js
@@ -1,7 +1,8 @@
 import React, { PureComponent } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
-
+import { ContextMenuTrigger } from 'react-contextmenu'
+import TabContextMenu from './TabContextMenu'
 import { UncontrolledTooltip } from 'reactstrap'
 
 class TabHeaderItem extends PureComponent {
@@ -12,10 +13,11 @@ class TabHeaderItem extends PureComponent {
     active: PropTypes.bool.isRequired,
     onSelectTab: PropTypes.func.isRequired,
     onCloseTab: PropTypes.func,
+    contextMenu: PropTypes.array,
   }
 
-  renderCloseBtn () {
-    const { tab, unsaved, saving, onCloseTab } = this.props
+  renderCloseBtn() {
+    const { tab, unsaved, saving, onCloseTab, contextMenu } = this.props
     if (!onCloseTab) {
       return null
     }
@@ -51,25 +53,47 @@ class TabHeaderItem extends PureComponent {
     )
   }
 
-  render () {
-    const { size, tab, tabText, active, onSelectTab, onCloseTab } = this.props
+  render() {
+    const { size, tab, tabText, active, onSelectTab, onCloseTab, contextMenu } = this.props
 
     return (
       <li className={classnames('nav-item', { active })}>
+
         <div
           className={classnames('btn d-flex flex-row align-items-center border-0 w-100', size && `btn-${size}`)}
-          onMouseDown={e => e.button === 0 && onSelectTab(tab)}
-          onMouseUp={e => e.button === 1 && onCloseTab && onCloseTab(tab)}
         >
           <div className='nav-item-content d-flex flex-row'>
-            <div className='nav-item-text'>
-              <div key={tab.key} className='d-flex flex-row align-items-center'>
-                {tabText}
+            <ContextMenuTrigger
+              id={`${tab.key}/tab-item`}
+              ref={ref => { this.clickableRef = ref }}
+              attributes={{
+                onClick: e => e.preventDefault()
+              }}
+            >
+              <div className='nav-item-text' onMouseDown={e => {
+                console.log(e)
+                e.button === 0 && onSelectTab(tab)
+
+              }}
+                onMouseUp={e => {
+                  console.log(e)
+                  e.button === 1 && onCloseTab && onCloseTab(tab)
+                }}>
+                <div key={tab.key} className='d-flex flex-row align-items-center'>
+                  {tabText}
+                </div>
               </div>
-            </div>
+              <TabContextMenu
+                node={tab}
+                contextMenu={contextMenu}
+              />
+            </ContextMenuTrigger>
+
           </div>
           {this.renderCloseBtn()}
+
         </div>
+
       </li>
     )
   }
@@ -86,10 +110,11 @@ export default class TabHeader extends PureComponent {
     onSelectTab: PropTypes.func.isRequired,
     onCloseTab: PropTypes.func,
     onNewTab: PropTypes.func,
+    contextMenu: PropTypes.array,
   }
 
-  render () {
-    const { className, size, tabs, selected, getTabText, onSelectTab, onCloseTab, ToolButtons = [] } = this.props
+  render() {
+    const { className, size, tabs, selected, getTabText, onSelectTab, onCloseTab, ToolButtons = [], contextMenu } = this.props
 
     return (
       <ul className={classnames('nav nav-tabs', className)}>
@@ -107,6 +132,7 @@ export default class TabHeader extends PureComponent {
                 active={selected.key === tab.key}
                 onSelectTab={onSelectTab}
                 onCloseTab={onCloseTab}
+                contextMenu={contextMenu}
               />
             )
           })
@@ -123,7 +149,7 @@ export default class TabHeader extends PureComponent {
             </div>
           </li>
         }
-        <div className='flex-grow-1'/>
+        <div className='flex-grow-1' />
         {
           ToolButtons.map((btn, index) => {
             const id = `tab-btn-${index}`

--- a/packages/ui-components/src/Tabs/Tabs.js
+++ b/packages/ui-components/src/Tabs/Tabs.js
@@ -13,6 +13,7 @@ export default class Tabs extends PureComponent {
     size: PropTypes.string,
     headerClassName: PropTypes.string,
     initialTabs: PropTypes.array,
+    tabContextMenu: PropTypes.array,
     initialSelected: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.object
@@ -213,6 +214,7 @@ export default class Tabs extends PureComponent {
           onNewTab={this.props.createNewTab && this.onNewTab}
           onCloseTab={this.props.noCloseTab ? undefined : this.onCloseTab}
           ToolButtons={this.props.ToolButtons}
+          contextMenu={this.props.tabContextMenu}
         />
         <div className='d-flex flex-1 flex-column overflow-hidden p-relative'>
           {Bar}

--- a/packages/ui-components/src/Tabs/TabsWithNavigationBar.js
+++ b/packages/ui-components/src/Tabs/TabsWithNavigationBar.js
@@ -88,6 +88,7 @@ export default class TabsWithNavigationBar extends PureComponent {
       initialTabs,
       onRefresh,
       NavbarButtons = null,
+      tabContextMenu = [],
       children,
     } = this.props
 
@@ -97,6 +98,7 @@ export default class TabsWithNavigationBar extends PureComponent {
         size='sm'
         initialSelected={tab}
         initialTabs={initialTabs}
+        tabContextMenu={tabContextMenu}
         getTabText={this.getTabText}
         onSelectTab={this.onSelectTab}
         createNewTab={this.createNewTab}

--- a/packages/workspace/src/ProjectManager/LocalProjectManager.js
+++ b/packages/workspace/src/ProjectManager/LocalProjectManager.js
@@ -35,13 +35,13 @@ export default class LocalProjectManager extends BaseProjectManager {
       projectSettings = await this.readProjectSettings()
     } catch (e) {
       console.warn(e)
-      return { initial: { path: this.settingsFilePath }, projectSettings: null }
+      return { initial: { path: this.settingsFilePath, pathInProject: this.settingsFilePath }, projectSettings: null }
     }
 
     if (await this.isMainValid()) {
-      return { initial: { path: this.mainFilePath }, projectSettings }
+      return { initial: { path: this.mainFilePath, pathInProject: this.mainFilePath }, projectSettings }
     }
-    return { initial: { path: this.settingsFilePath }, projectSettings }
+    return { initial: { path: this.settingsFilePath, pathInProject: this.settingsFilePath }, projectSettings }
   }
 
   pathForProjectFile (relativePath) {

--- a/packages/workspace/src/ProjectManager/RemoteProjectManager.js
+++ b/packages/workspace/src/ProjectManager/RemoteProjectManager.js
@@ -39,10 +39,10 @@ export default class RemoteProjectManager extends BaseProjectManager {
       projectSettings = await this.readProjectSettings()
     } catch (e) {
       console.warn(e)
-      return { initial: { path: this.pathForProjectFile('README.md'), remote: true }, projectSettings: null }
+      return { initial: { path: this.pathForProjectFile('README.md'), remote: true, pathInProject: this.pathInProject(this.pathForProjectFile('README.md')) }, projectSettings: null }
     }
 
-    return { initial: { path: this.pathForProjectFile('README.md'), remote: true }, projectSettings }
+    return { initial: { path: this.pathForProjectFile('README.md'), remote: true, pathInProject: this.pathInProject(this.pathForProjectFile('README.md')) }, projectSettings }
   }
 
   async deleteProject () {

--- a/packages/workspace/src/components/Workspace.js
+++ b/packages/workspace/src/components/Workspace.js
@@ -88,10 +88,10 @@ export default class Workspace extends Component {
     this.disposable()
   }
 
-  tabFromPath = (filePath, remote) => ({ path: filePath, key: filePath, remote })
+  tabFromPath = (filePath, remote, pathInProject) => ({ path: filePath, key: filePath, remote, pathInProject })
 
-  openFile = ({ path, remote }, setTreeActive) => {
-    this.codeEditor.current.openTab(this.tabFromPath(path, remote))
+  openFile = ({ path, remote, pathInProject }, setTreeActive) => {
+    this.codeEditor.current.openTab(this.tabFromPath(path, remote, pathInProject))
 
     if (path.startsWith('custom:')) {
       this.filetree.current.setNoActive()
@@ -207,7 +207,7 @@ export default class Workspace extends Component {
             key={this.context.projectRoot}
             theme={theme}
             editorConfig={editorConfig}
-            initialTab={this.tabFromPath(initial.path, initial.remote)}
+            initialTab={this.tabFromPath(initial.path, initial.remote, initial.pathInProject)}
             projectRoot={this.context.projectRoot}
             projectManager={this.context.projectManager}
             onSelectTab={this.onSelectTab}
@@ -223,7 +223,7 @@ export default class Workspace extends Component {
           key={this.context.projectRoot}
           theme={theme}
           editorConfig={editorConfig}
-          initialTab={this.tabFromPath(initial.path, initial.remote)}
+          initialTab={this.tabFromPath(initial.path, initial.remote, initial.pathInProject)}
           projectRoot={this.context.projectRoot}
           projectManager={this.context.projectManager}
           onSelectTab={this.onSelectTab}

--- a/packages/workspace/src/components/contextMenu.js
+++ b/packages/workspace/src/components/contextMenu.js
@@ -1,4 +1,4 @@
-import platform from '@obsidians/platform'
+import platform, { ClipBoardService } from '@obsidians/platform'
 import fileOps from '@obsidians/file-ops'
 
 const handlers = {}
@@ -9,6 +9,13 @@ const showInFinder = node => {
   } else {
     fileOps.current.showItemInFolder(node.path)
   }
+}
+
+const copyPath = ({ path, pathInProject }) => {
+  const filePath = pathInProject || path
+  const clipboard = new ClipBoardService()
+
+  clipboard.writeText(filePath)
 }
 
 const openInTerminal = node => {
@@ -34,6 +41,8 @@ if (platform.isDesktop) {
     { text: 'Open Containing Folder', onClick: showInFinder },
     { text: 'Open in Terminal', onClick: openInTerminal },
     null,
+    { text: 'Copy Path', onClick: copyPath },
+    null,
     { text: 'Rename', onClick: node => handlers.rename(node) },
     { text: 'Delete', onClick: node => handlers.deleteFile(node) },
   ]
@@ -43,6 +52,8 @@ if (platform.isDesktop) {
     { text: 'New Folder', onClick: node => handlers.newFolder(node) },
     // null,
     // { text: 'Download' },
+    null,
+    { text: 'Copy Path', onClick: copyPath },
     null,
     { text: 'Rename', onClick: node => handlers.rename(node) },
     { text: 'Delete', onClick: node => handlers.deleteFile(node) },


### PR DESCRIPTION
added some context menus of tab in code-editor section:

- [x] close
- [x] close others
- [x] close all
- [x] copy path
- [x] open containing folder

Note: the copy path format of a file is different between online editor and desktop editor:
- online editor: `projectName/**/filename`
- desktop editor: `/Users/username/dir/**/projectName/**/filename`

will add the menu of the copy relative path in another pr.

**web-editor screenshots:**
> web editor should not have the "Open Containing Folder"

| file tree      |  tab |
| ----------- | ----------- |
![image](https://user-images.githubusercontent.com/20736452/144173466-c95f23c3-aabd-4f35-92fc-44fd1a3f8071.png)|![image](https://user-images.githubusercontent.com/20736452/144173528-e30e8bef-4f67-4f65-9c21-9039b459f379.png)



**desktop-editor screenshots:**
| file tree      |  tab |
| ----------- | ----------- |
![image](https://user-images.githubusercontent.com/20736452/144173631-ee10ebd6-bae9-4d0f-87c0-e1b115ae7e40.png)|![image](https://user-images.githubusercontent.com/20736452/144173648-1a664c2f-2f5a-416e-9a6b-ff2eac4acd39.png)