### PR TITLE
fix: can not open project after upgrade

### DIFF
--- a/packages/file-ops/main/index.js
+++ b/packages/file-ops/main/index.js
@@ -1,5 +1,5 @@
 const { IpcChannel } = require('@obsidians/ipc')
-const { app, dialog, shell, getCurrentWindow } = require('electron')
+const { app, dialog, shell, BrowserWindow } = require('electron')
 const path = require('path')
 const os = require('os')
 const trash = require('trash')
@@ -22,7 +22,7 @@ class FileOpsChannel extends IpcChannel {
   }
 
   async showOpenDialog (options) {
-    return dialog.showOpenDialog(getCurrentWindow(), options)
+    return dialog.showOpenDialog(BrowserWindow.getFocusedWindow(), options)
   }
 
   showMessageBox ({ message, buttons }) {

--- a/packages/global/src/modals/AboutModal.js
+++ b/packages/global/src/modals/AboutModal.js
@@ -33,7 +33,7 @@ export default class AboutModal extends PureComponent {
     if (this.state.debugCounter > 20) {
       try {
         console.info('Dev Tools Toggled')
-        window.require('electron').remote.getCurrentWindow().toggleDevTools()
+        window.require('electron').BrowserWindow.getFocusedWindow().toggleDevTools()
       } catch (e) {}
       this.setState({ debugCounter: 0 })
     } else {

--- a/packages/ui-components/src/Modal.js
+++ b/packages/ui-components/src/Modal.js
@@ -170,7 +170,7 @@ export default class BaseModal extends PureComponent {
           {title}
         </ModalHeader>
         <ModalBody
-          className={classnames('d-flex flex-column')}
+          className={classnames('d-flex flex-column', !overflow && 'overflow-auto')}
         >
           {children}
           {errorComponent}


### PR DESCRIPTION
cause: the remote module has deprecated from the electron
ref:
- https://github.com/electron/electron/issues/21408
- https://www.electronjs.org/docs/latest/breaking-changes#planned-breaking-api-changes-140

just use the "getFocusedWindow" to replace "getCurrentWindow".