### PR TITLE
feat: disable switch tab when trigger context menu

### DIFF
--- a/packages/code-editor/src/CodeEditorCollection.js
+++ b/packages/code-editor/src/CodeEditorCollection.js
@@ -97,14 +97,14 @@ export default class CodeEditorCollection extends PureComponent {
     return tab => modelSessionManager.closeModelSession(tab.path)
   }
 
-  closeCurrentFile = () => {
-    const { onCloseTab, currentTab } = this.tabs.current
-    onCloseTab(currentTab)
+  closeCurrentFile = tab => {
+    const { onCloseTab } = this.tabs.current
+    onCloseTab(tab)
   }
 
   // MARK: may can define a batch delete in the Tabs component
-  closeOtherFiles = () => {
-    const { onCloseTab, currentTab, allTabs } = this.tabs.current;
+  closeOtherFiles = currentTab => {
+    const { onCloseTab, allTabs } = this.tabs.current;
     const shouldCloseTabs = allTabs.filter(tab => tab.key !== currentTab.key);
 
     shouldCloseTabs.forEach(tab => {

--- a/packages/ui-components/src/Tabs/TabHeader.js
+++ b/packages/ui-components/src/Tabs/TabHeader.js
@@ -157,7 +157,7 @@ const SortableTab = DragSource(Types.TAB, cardSource, sourceCollect)(DropTarget(
 
 const TabHeader = ({ className, size, tabs, selected, getTabText, onSelectTab, ToolButtons = [], onCloseTab, onNewTab, contextMenu, onDragTab }) => {
   const treeNodeContextMenu = typeof contextMenu === 'function' ? contextMenu(selected) : contextMenu
-  const [selectNode, setSelctNode] = useState(selected)
+  const [selectNode, setSelectNode] = useState(selected)
 
   const { show } = useContextMenu({
     id: 'tab-context-menu'
@@ -169,8 +169,7 @@ const TabHeader = ({ className, size, tabs, selected, getTabText, onSelectTab, T
     }
 
     event.nativeEvent.preventDefault()
-    setSelctNode(tab)
-    onSelectTab(tab)
+    setSelectNode(tab)
     show(event.nativeEvent, {
       props: {
         key: 'value'


### PR DESCRIPTION
| before | after |
|---|----|
|![image](https://user-images.githubusercontent.com/20736452/148013477-a8eb835f-96dc-474d-a12a-8191e66d449a.png)|![image](https://user-images.githubusercontent.com/20736452/148013365-4f88dc39-7a67-4b4f-960c-263f10acd7e1.png)

the tab should not be focused when triggering the context menu display
