### PR TITLE
fix: center the close btn and fix plus sign's bg-color error in desktop.

### DIFF
--- a/packages/ui-components/src/Tabs/TabHeader.js
+++ b/packages/ui-components/src/Tabs/TabHeader.js
@@ -219,8 +219,6 @@ const TabHeader = ({ className, size, tabs, selected, getTabText, onSelectTab, T
     scrollCurrentIntoView()
   },[selected]);
 
-  const isInTab = tabs[0] && tabs[0].key.indexOf('tab') !== -1
-  console.log(ToolButtons)
   return (
     <div className='nav-top-bar overflow-hidden'>
       <DndProvider backend={HTML5Backend}>

--- a/packages/ui-components/src/Tabs/TabHeader.js
+++ b/packages/ui-components/src/Tabs/TabHeader.js
@@ -6,6 +6,7 @@ import { DragSource, DropTarget, DndProvider } from 'react-dnd'
 import { HTML5Backend } from 'react-dnd-html5-backend'
 import { Menu, Item, useContextMenu, Separator } from 'react-contexify'
 import throttle from 'lodash/throttle'
+import platform from '@obsidians/platform'
 
 const Types = {
   TAB: 'tab'
@@ -259,7 +260,7 @@ const TabHeader = ({ className, size, tabs, selected, getTabText, onSelectTab, T
               </span>
             </div>
             }
-            <div onDoubleClick={onNewTab} className={classnames('flex-grow-1', {'border-bottom-tab': tabs.length !== 0 })} />
+            <div onDoubleClick={onNewTab} className={classnames('flex-grow-1', {'border-bottom-tab': tabs.length !== 0 || platform.isDesktop })} />
             {
               ToolButtons.map((btn, index) => {
                 const id = `tab-btn-${index}`

--- a/packages/ui-components/src/Tabs/styles.scss
+++ b/packages/ui-components/src/Tabs/styles.scss
@@ -12,7 +12,7 @@
       background-color: var(--color-bg-invalid);
       overflow-x: scroll;
       overflow-y: hidden;
-      height: 3rem;
+      height: 60px;
       transition: all 0.5s ease-in-out;
 
       &>.nav-item {

--- a/packages/ui-components/src/Tabs/styles.scss
+++ b/packages/ui-components/src/Tabs/styles.scss
@@ -26,6 +26,7 @@
         margin-bottom: -1px;
         white-space: nowrap;
         flex-shrink: 0;
+        height: 30px;
 
         &:hover {
           background: var(--color-hover);
@@ -61,15 +62,12 @@
 
           & .nav-item-content {
             overflow: hidden;
-            line-height: 1;
 
             .nav-item-text {
               overflow: hidden;
               max-width: 200px;
               text-overflow: ellipsis;
               user-select: none;
-
-
 
               &>div {
                 span {


### PR DESCRIPTION
- [x]  center the close icon.
- [x]  the entire row has background color when the last tab closed in desktop