### PR TITLE
feat: pass decorations from code-editor to file-tree

### DIFF
--- a/packages/code-editor/src/CodeEditorCollection.js
+++ b/packages/code-editor/src/CodeEditorCollection.js
@@ -15,6 +15,7 @@ export default class CodeEditorCollection extends PureComponent {
     onSelectTab: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     theme: PropTypes.string,
+    onChangeDecorations: PropTypes.func.isRequired
   }
 
   constructor (props) {
@@ -249,6 +250,7 @@ export default class CodeEditorCollection extends PureComponent {
             readOnly={readOnly}
             onChange={this.setCurrentTabUnsaved}
             onCommand={this.onCommand}
+            onChangeDecorations={this.props.onChangeDecorations}
           />
         </Tabs>
       </div>

--- a/packages/code-editor/src/MonacoEditor/MonacoEditor.js
+++ b/packages/code-editor/src/MonacoEditor/MonacoEditor.js
@@ -14,7 +14,8 @@ export default class MonacoEditor extends Component {
     readOnly: PropTypes.bool,
     modelSession: PropTypes.object.isRequired,
     onCommand: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    onChangeDecorations: PropTypes.func.isRequired
   }
 
   componentDidMount () {
@@ -22,6 +23,17 @@ export default class MonacoEditor extends Component {
 
     this.throttledLayoutEditor = throttle(this.layoutEditor, 500)
     this.monacoEditor = this.createEditorWith(this.props.modelSession.model)
+    
+    this.monacoEditor.onDidChangeModelDecorations(() => {
+      const compileMarkerMap = modelSessionManager.decorationMap
+      const decorations = Object.keys(compileMarkerMap).map(path => ({
+        [path]: {
+          warning: compileMarkerMap[path]?.filter(item => item.type === 'warning').length || 0,
+          error: compileMarkerMap[path]?.filter(item => item.type === 'error').length || 0,
+        }
+      }))
+      this.props.onChangeDecorations(decorations)
+    })
 
     this.throttledLayoutEditor()
     // api.bridge.send('languageClient.create')

--- a/packages/code-editor/src/MonacoEditor/MonacoEditorContainer.js
+++ b/packages/code-editor/src/MonacoEditor/MonacoEditorContainer.js
@@ -14,7 +14,8 @@ export default class MonacoEditorContainer extends PureComponent {
   static propTypes = {
     readOnly: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
-    onCommand: PropTypes.func.isRequired
+    onCommand: PropTypes.func.isRequired,
+    onChangeDecorations: PropTypes.func.isRequired
   }
 
   state = {
@@ -108,6 +109,7 @@ export default class MonacoEditorContainer extends PureComponent {
         onCommand={onCommand}
         readOnly={readOnly}
         onChange={() => onChange(true)}
+        onChangeDecorations={this.props.onChangeDecorations}
       />
       <CustomTabContainer
         loading={loading}

--- a/packages/code-editor/src/MonacoEditor/modelSessionManager/index.js
+++ b/packages/code-editor/src/MonacoEditor/modelSessionManager/index.js
@@ -40,7 +40,7 @@ class ModelSessionManager {
   tabsRef = null
   editorRef = null
 
-  updateEditorAfterMovedFile (oldPath, newPath) {
+  updateEditorAfterMovedFile(oldPath, newPath) {
     // include move file and rename file
     if (!this.sessions[oldPath]) return
 
@@ -53,12 +53,12 @@ class ModelSessionManager {
     const oldTab = tabsState.tabs.find(tab => tab.path.endsWith(oldPath))
     if (!oldTab) return
     const tab = {
-        path: oldTab.path && oldTab.path.replace(oldPath, newPath),
-        key: oldTab.key && oldTab.key.replace(oldPath, newPath),
-        pathInProject: oldTab.pathInProject && oldTab.pathInProject.replace(oldPath, newPath),
-        remote: oldTab.remote,
-      }
-    const newTab = this.tabsRef.current.updateTab(tab ,oldTab.key)
+      path: oldTab.path && oldTab.path.replace(oldPath, newPath),
+      key: oldTab.key && oldTab.key.replace(oldPath, newPath),
+      pathInProject: oldTab.pathInProject && oldTab.pathInProject.replace(oldPath, newPath),
+      remote: oldTab.remote,
+    }
+    const newTab = this.tabsRef.current.updateTab(tab, oldTab.key)
     if (this.currentFilePath !== oldPath) return
     this.tabsRef.current.changeCurrentTab(newTab)
     this.currentModelSession = this.sessions[newPath]
@@ -67,9 +67,7 @@ class ModelSessionManager {
     })
   }
 
-
-
-  replaceModelSession(oldPath, newPath){
+  replaceModelSession(oldPath, newPath) {
     const uri = monaco.Uri.file(newPath)
     const newModel = monaco.editor.createModel(this.sessions[oldPath]._model.value, this.sessions[oldPath]._model._languageIdentifier.language, uri)
 
@@ -85,7 +83,7 @@ class ModelSessionManager {
     return new MonacoEditorModelSession(newModel, this.sessions[oldPath]._remote, this.sessions[oldPath]._CustomTab, this.sessions[oldPath].decorations)
   }
 
-  set editorContainer (editorContainer) {
+  set editorContainer(editorContainer) {
     this._editorContainer = editorContainer
   }
 
@@ -112,6 +110,7 @@ class ModelSessionManager {
   registerModeDetector(modeDetector) {
     this.modeDetector = modeDetector
   }
+
   registerCustomTab(mode, CustomTab, title) {
     this.CustomTabs[mode] = CustomTab
     if (title) {
@@ -311,7 +310,7 @@ class ModelSessionManager {
     this._editorContainer.refresh()
   }
 
-  clearDecoration (type) {
+  clearDecoration(type) {
     const decorationMap = this.decorationMap
     Object.keys(this.decorationMap).forEach(filePath => {
       if (this.sessions[filePath]) {
@@ -331,7 +330,8 @@ class ModelSessionManager {
     const linterMarkers = decorations.filter(item => item.from === 'linter')
     const compilerMarkers = decorations.filter(item => item.from === 'compiler')
     const decorationMap = this.decorationMap
-    
+
+
     decorations.forEach(item => {
       if (!decorationMap[item.filePath]) {
         decorationMap[item.filePath] = []
@@ -348,7 +348,7 @@ class ModelSessionManager {
           decorationMap[item.filePath] = restLinters.concat(compilerMarkers.filter(c => c.filePath === item.filePath))
         }
       }
-      
+
     })
 
     this.decorationMap = decorationMap

--- a/packages/filetree/src/index.js
+++ b/packages/filetree/src/index.js
@@ -310,9 +310,11 @@ const FileTree = ({ projectManager, onSelect, contextMenu, readOnly = false }, r
     </div>
   )
 }
+
 const ForwardFileTree = React.forwardRef(FileTree)
 ForwardFileTree.displayName = 'FileTree'
 
 export default ForwardFileTree
 
+// TOOD: refactor the dir contruct of the service
 export { default as ClipBoardService } from "./clipboard"

--- a/packages/workspace/src/components/Workspace.js
+++ b/packages/workspace/src/components/Workspace.js
@@ -34,7 +34,7 @@ SplitPane.getSizeUpdate = (props, state) => {
 export default class Workspace extends Component {
   static contextType = WorkspaceContext
 
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.filetree = React.createRef()
     this.codeEditor = React.createRef()
@@ -48,6 +48,7 @@ export default class Workspace extends Component {
       editorConfig: {},
       showTerminal: !!props.terminal,
       terminalSize: 160,
+      filetreeDecorations: []
     }
 
     const effect = BaseProjectManager.effect(`settings:editor`, editorConfig => {
@@ -66,12 +67,12 @@ export default class Workspace extends Component {
     })
   }
 
-  componentDidMount () {
+  componentDidMount() {
     const editorConfig = this.context.projectSettings.get('editor')
     this.setState({ editorConfig })
   }
 
-  async componentDidUpdate (prevProps) {
+  async componentDidUpdate(prevProps) {
     if (prevProps.terminal !== this.props.terminal) {
       if (this.props.terminal) {
         this.setState({
@@ -85,7 +86,7 @@ export default class Workspace extends Component {
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     this.disposable()
   }
 
@@ -171,7 +172,7 @@ export default class Workspace extends Component {
     }
   }
 
-  render () {
+  render() {
     const {
       theme,
       initial,
@@ -215,6 +216,9 @@ export default class Workspace extends Component {
             projectManager={this.context.projectManager}
             onSelectTab={this.onSelectTab}
             readOnly={readOnly}
+            onChangeDecorations={(decorations) => this.setState({
+              filetreeDecorations: decorations
+            })}
           />
           {Terminal}
         </SplitPane>
@@ -231,6 +235,9 @@ export default class Workspace extends Component {
           projectManager={this.context.projectManager}
           onSelectTab={this.onSelectTab}
           readOnly={readOnly}
+          onChangeDecorations={(decorations) => this.setState({
+            filetreeDecorations: decorations
+          })}
         />
       )
     }
@@ -258,13 +265,14 @@ export default class Workspace extends Component {
               onClick={() => this.openCreateFileModal()}
             />
             <ProjectToolbar
-              signer={signer}/>
+              signer={signer} />
           </div>
           <FileTree
             ref={this.filetree}
             projectManager={this.context.projectManager}
             initialPath={initial.path}
             onSelect={this.openFile}
+            decorations={this.state.filetreeDecorations}
             readOnly={readOnly}
             contextMenu={makeContextMenu(contextMenu, this.context.projectManager)}
           />


### PR DESCRIPTION
the PR aim at passing the decorations data from code-editor to file-tree, so that the file tree can display the status of errors from linter or compiler.

the data construction:
```javascript
decorations = {
  <filepath>: {warning: <number>, error: <number>}[]
}
```