### PR TITLE
Fix：file tree keypress

### DIFF
--- a/packages/file-ops/main/index.js
+++ b/packages/file-ops/main/index.js
@@ -53,6 +53,14 @@ class FileOpsChannel extends IpcChannel {
       this.exec(`gnome-terminal --working-directory=${filePath}`)
     }
   }
+
+  async trashFile (filePath) {
+    try {
+      await shell.trashItem(path.normalize(filePath))
+    } catch (e) {
+      throw new Error(e)
+    }
+  }
 }
 
 module.exports = FileOpsChannel

--- a/packages/file-ops/package.json
+++ b/packages/file-ops/package.json
@@ -11,8 +11,7 @@
     "filehound": "^1.17.4",
     "fs-extra": "^9.1.0",
     "lodash": "^4.17.20",
-    "path-browserify": "^1.0.1",
-    "trash": "^7.0.0"
+    "path-browserify": "^1.0.1"
   },
   "peerDependencies": {
     "aws-sdk": "^2.830.0",

--- a/packages/file-ops/src/ElectronFileOps.js
+++ b/packages/file-ops/src/ElectronFileOps.js
@@ -1,6 +1,7 @@
 // TODO: re integrate file ops with workspace
 import { IpcChannel } from '@obsidians/ipc'
 import FileOps from './FileOps'
+const path = require('path')
 
 export default class ElectronFileOps extends FileOps {
   constructor () {
@@ -10,7 +11,6 @@ export default class ElectronFileOps extends FileOps {
 
     this.channel = new IpcChannel('file-ops')
     this.electron = window.require('electron')
-    this.trash = window.require('trash')
 
     this.channel.invoke('getPaths').then(result => {
       this.homePath = result.homePath
@@ -161,6 +161,10 @@ export default class ElectronFileOps extends FileOps {
   }
 
   async deleteFile (filePath) {
-    return await this.trash([filePath])
+    const dir = path.dirname(filePath)
+    const baseName = path.basename(filePath)
+    await this.channel.invoke('trashFile', path.join(dir, baseName)).catch(e => {
+      console.error(e)
+    })
   }
 }

--- a/packages/filetree/src/helper.js
+++ b/packages/filetree/src/helper.js
@@ -84,11 +84,14 @@ const checkFatherNode = (curNode, targetNode, fn) => {
 
 const findFather = (fn) => (curNode, targetName) => checkFatherNode(curNode, targetName, fn)
 
-const findChildren = (treeData, name) => treeData.children.find(item => item.name.toLowerCase() === name)
+const findChildren = (treeData, path) => treeData.children.find(item => item.path === path)
+
+const filterDuplicate = arr => Array.from(new Set(arr))
 
 export {
   updateErrorInfo,
   travelTree,
   findFather,
-  findChildren
+  findChildren,
+  filterDuplicate
 }

--- a/packages/filetree/src/hooks/useBatchLoad.js
+++ b/packages/filetree/src/hooks/useBatchLoad.js
@@ -14,13 +14,13 @@ const useBatchLoad = ({ treeData, projectManager, getNewTreeData, setTreeData })
       } catch (e) {
         reject(e)
       }
-      task.push({ key: treeNode.path, value: folderData })
+      task.push({ pathKey: treeNode.path, pathValue: folderData })
       clearTimeout(timer)
       timer = setTimeout(() => {
         let tempTreeData = cloneDeep(treeData)
         task.forEach(item => {
           Object.keys(item).length === 0 && resolve()
-          getNewTreeData(tempTreeData, item.key, item.value)
+          getNewTreeData(tempTreeData, item.pathKey, item.pathValue)
         })
         setTreeData(tempTreeData)
         waitingTime = 200

--- a/packages/filetree/src/index.js
+++ b/packages/filetree/src/index.js
@@ -6,7 +6,11 @@ import './styles.css'
 import { Menu, Item, useContextMenu, Separator } from 'react-contexify'
 import 'react-contexify/dist/ReactContexify.min.css'
 import StatusTitle from './statusTitle'
-import {travelTree, updateErrorInfo, findFather, findChildren} from './helper'
+import { travelTree,
+  updateErrorInfo,
+  findFather,
+  findChildren,
+  filterDuplicate } from './helper'
 import { modelSessionManager } from '@obsidians/code-editor'
 import PropTypes from 'prop-types'
 import useBatchLoad from './hooks/useBatchLoad'
@@ -70,11 +74,9 @@ const getNewTreeData = (treeData, curKey, child) => {
   const loop = data => {
     data.forEach(item => {
       if (curKey.indexOf(item.path) === 0) {
-        if (item.children?.length > 0) {
-          loop(item.children)
-        } else {
-          item.children = child
-        }
+        item.children?.length > 0
+            ? loop(item.children)
+            : item.children = item.key === curKey ? child : []
       }
     })
   }
@@ -101,8 +103,6 @@ const replaceTreeNode = (treeData, curKey, child) => {
 const FileTree = forwardRef(({ projectManager, onSelect, move, copy, initialPath, contextMenu, readOnly = false }, ref) => {
   const treeRef = React.useRef()
   const [treeData, setTreeData] = useState([])
-  const cacheRef = React.useRef()
-  cacheRef.current = treeData
   const [autoExpandParent, setAutoExpandParent] = useState(true)
   const [expandedKeys, setExpandKeys] = useState([])
   const [selectedKeys, setSelectedKeys] = useState([initialPath])
@@ -238,7 +238,6 @@ const FileTree = forwardRef(({ projectManager, onSelect, move, copy, initialPath
             handleExpand(expandedKeys.concat([key]),{node: ref.current.activeNode})
           }
         }
-        // treeRef.current.onNodeExpand(event, node)
       },
       setNoActive() {
         setSelectedKeys([])
@@ -280,11 +279,28 @@ const FileTree = forwardRef(({ projectManager, onSelect, move, copy, initialPath
       setExpandKeys([treeData.path])
       treeRef.current && (treeRef.current.state.loadedKeys = [])
       if (initFetch) {
-        const ReadMeNode = projectManager.remote
-            ? findChildren(treeData, 'readme.md')
-           : findChildren(treeData, 'config.json')
-        setSelectNode(ReadMeNode)
+        setSelectedKeys([initialPath])
+        setSelectNode(findChildren(treeData, initialPath))
       }
+    }
+
+    const handleClick = (event, node) => {
+      onDebounceClick(event, node)
+    }
+
+    const clickFolderNode = (event, node) => {
+      if (node.isLeaf) return
+      if (treeRef.current) {
+        treeRef.current.onNodeExpand(event, node)
+        setSelectNode(node)
+      }
+    }
+
+    const handleExpand = (keys, { node }) => {
+      if (node.root || !!dragTarget || node.isLeaf) return
+      setAutoExpandParent(false)
+      setExpandKeys(keys)
+      selectNode(node)
     }
 
     const handleSelect = (_, { node }) => {
@@ -298,21 +314,6 @@ const FileTree = forwardRef(({ projectManager, onSelect, move, copy, initialPath
       getNewTreeData,
       setTreeData
     })
-
-    const handleExpand = (keys, { node }) => {
-      if (node.root || !!dragTarget) return
-      setAutoExpandParent(false)
-      setExpandKeys(keys)
-      setSelectNode(node)
-    }
-
-    const expandFolderNode = (event, node) => {
-      if (node.isLeaf) return
-      if (treeRef.current) {
-        treeRef.current.onNodeExpand(event, node)
-        setSelectNode(node)
-      }
-    }
 
     const enableHighLightBlock = (tree, needHighLight) => {
       const refreshClassName = (node) => {
@@ -367,10 +368,6 @@ const FileTree = forwardRef(({ projectManager, onSelect, move, copy, initialPath
       event.currentTarget.parentElement.id = ''
     }
 
-    const handleClick = (event, node) => {
-      onDebounceExpand(event, node)
-    }
-
     const disableFather = (node, targetNode) => {
       node.className = 'father--disable'
       setDragTarget(targetNode)
@@ -412,7 +409,7 @@ const FileTree = forwardRef(({ projectManager, onSelect, move, copy, initialPath
       if (projectManager.remote) return
       setCopyNode(selectNode)
       setMoveNode(null)
-    }, [treeNodeContextMenu, selectNode, copyNode])
+    }, [treeNodeContextMenu, selectNode, copyNode, selectedKeys])
 
     useHotkeys('ctrl+v, cmd+v', () => {
       if (projectManager.remote) return
@@ -428,9 +425,10 @@ const FileTree = forwardRef(({ projectManager, onSelect, move, copy, initialPath
             ? copy(copyNode) // handle copy event without given a new path of copied file
             : copy(copyNode, selectNode, true) // handle copy event with given a new path of copied file
       }
-    }, [treeNodeContextMenu, copyNode, selectNode])
+      setExpandKeys(filterDuplicate([...expandedKeys, selectNode.key]))
+    }, [treeNodeContextMenu, copyNode, selectNode, expandedKeys])
 
-    const onDebounceExpand = debounce(expandFolderNode, 200, { leading: true })
+    const onDebounceClick = debounce(clickFolderNode, 200, { leading: true })
 
     const onDebounceDrop = debounce(handleDrop, 200, { leading: true })
 

--- a/packages/workspace/src/ProjectManager/LocalProjectManager.js
+++ b/packages/workspace/src/ProjectManager/LocalProjectManager.js
@@ -212,9 +212,9 @@ export default class LocalProjectManager extends BaseProjectManager {
     if (fromIsFile) {
       dest = hasCopyName
           ? from.replace(matchRule, getCount(hasCopyName))
-          : needMove ? `${toDir}/${fromName}${fromExt}` : `${toDir}/${fromName}-copy1${fromExt}`
+          : needMove ? `${toDir}/${fromName}${fromExt}` : `${toDir}/${fromName} copy1${fromExt}`
     } else {
-      const copiedName = toDir.replace(fromName, `${fromName}-copy1`)
+      const copiedName = toDir.replace(fromName, `${fromName} copy1`)
       dest = hasCopyName
           ? from.replace(matchRule, getCount(hasCopyName))
           : needMove ? `${toDir}/${fromName}` : copiedName
@@ -226,10 +226,11 @@ export default class LocalProjectManager extends BaseProjectManager {
       if (matched) {
         dest = dest.replace(matchRule, getCount(matched))
       } else {
-        const copiedName = toDir.replace(fromName, `${fromName}-copy1`)
-        dest = fromIsFile ? `${toDir}/${fromName}-copy1${fromExt}` : copiedName
+        const copiedName = toDir.replace(fromName, `${fromName} copy1`)
+        dest = fromIsFile ? `${toDir}/${fromName} copy1${fromExt}` : copiedName
       }
     }
+
     try {
       await this.copy(from, dest)
     } catch (e) {


### PR DESCRIPTION
- [x] fix: set README.md as defaulted open file
- [x]  fix: duplicated file causes loading tree data error 
- [x] fix: keep the target folder  in an open status after copying a file or cutting a file
- [x] fix: delete file failed issue

