### PR TITLE
fix: filetree keypress bug

### DIFF
--- a/packages/file-ops/main/index.js
+++ b/packages/file-ops/main/index.js
@@ -53,6 +53,14 @@ class FileOpsChannel extends IpcChannel {
       this.exec(`gnome-terminal --working-directory=${filePath}`)
     }
   }
+
+  async trashFile (filePath) {
+    try {
+      await shell.trashItem(path.normalize(filePath))
+    } catch (e) {
+      throw new Error(e)
+    }
+  }
 }
 
 module.exports = FileOpsChannel

--- a/packages/file-ops/package.json
+++ b/packages/file-ops/package.json
@@ -11,8 +11,7 @@
     "filehound": "^1.17.4",
     "fs-extra": "^9.1.0",
     "lodash": "^4.17.20",
-    "path-browserify": "^1.0.1",
-    "trash": "^7.0.0"
+    "path-browserify": "^1.0.1"
   },
   "peerDependencies": {
     "aws-sdk": "^2.830.0",

--- a/packages/file-ops/src/ElectronFileOps.js
+++ b/packages/file-ops/src/ElectronFileOps.js
@@ -1,6 +1,7 @@
 // TODO: re integrate file ops with workspace
 import { IpcChannel } from '@obsidians/ipc'
 import FileOps from './FileOps'
+const path = require('path')
 
 export default class ElectronFileOps extends FileOps {
   constructor () {
@@ -10,7 +11,6 @@ export default class ElectronFileOps extends FileOps {
 
     this.channel = new IpcChannel('file-ops')
     this.electron = window.require('electron')
-    this.trash = window.require('trash')
 
     this.channel.invoke('getPaths').then(result => {
       this.homePath = result.homePath
@@ -161,6 +161,10 @@ export default class ElectronFileOps extends FileOps {
   }
 
   async deleteFile (filePath) {
-    return await this.trash([filePath])
+    const dir = path.dirname(filePath)
+    const baseName = path.basename(filePath)
+    await this.channel.invoke('trashFile', path.join(dir, baseName)).catch(e => {
+      console.error(e)
+    })
   }
 }

--- a/packages/filetree/src/helper.js
+++ b/packages/filetree/src/helper.js
@@ -84,11 +84,14 @@ const checkFatherNode = (curNode, targetNode, fn) => {
 
 const findFather = (fn) => (curNode, targetName) => checkFatherNode(curNode, targetName, fn)
 
-const findChildren = (treeData, name) => treeData.children.find(item => item.name.toLowerCase() === name)
+const findChildren = (treeData, path) => treeData.children.find(item => item.path === path)
+
+const filterDuplicate = arr => Array.from(new Set(arr))
 
 export {
   updateErrorInfo,
   travelTree,
   findFather,
-  findChildren
+  findChildren,
+  filterDuplicate
 }

--- a/packages/filetree/src/hooks/useBatchLoad.js
+++ b/packages/filetree/src/hooks/useBatchLoad.js
@@ -14,13 +14,13 @@ const useBatchLoad = ({ treeData, projectManager, getNewTreeData, setTreeData })
       } catch (e) {
         reject(e)
       }
-      task.push({ key: treeNode.path, value: folderData })
+      task.push({ pathKey: treeNode.path, pathValue: folderData })
       clearTimeout(timer)
       timer = setTimeout(() => {
         let tempTreeData = cloneDeep(treeData)
         task.forEach(item => {
           Object.keys(item).length === 0 && resolve()
-          getNewTreeData(tempTreeData, item.key, item.value)
+          getNewTreeData(tempTreeData, item.pathKey, item.pathValue)
         })
         setTreeData(tempTreeData)
         waitingTime = 200

--- a/packages/workspace/src/ProjectManager/LocalProjectManager.js
+++ b/packages/workspace/src/ProjectManager/LocalProjectManager.js
@@ -42,7 +42,7 @@ export default class LocalProjectManager extends BaseProjectManager {
     if (await this.isMainValid()) {
       return { initial: { path: this.mainFilePath, pathInProject: this.mainFilePath }, projectSettings }
     }
-    return { initial: { path: this.settingsFilePath, pathInProject: this.settingsFilePath }, projectSettings }
+    return { initial: { path: this.pathForProjectFile('README.md'), pathInProject: this.settingsFilePath }, projectSettings }
   }
 
   pathForProjectFile(relativePath) {
@@ -212,9 +212,9 @@ export default class LocalProjectManager extends BaseProjectManager {
     if (fromIsFile) {
       dest = hasCopyName
           ? from.replace(matchRule, getCount(hasCopyName))
-          : needMove ? `${toDir}/${fromName}${fromExt}` : `${toDir}/${fromName}-copy1${fromExt}`
+          : needMove ? `${toDir}/${fromName}${fromExt}` : `${toDir}/${fromName} copy1${fromExt}`
     } else {
-      const copiedName = toDir.replace(fromName, `${fromName}-copy1`)
+      const copiedName = toDir.replace(fromName, `${fromName} copy1`)
       dest = hasCopyName
           ? from.replace(matchRule, getCount(hasCopyName))
           : needMove ? `${toDir}/${fromName}` : copiedName
@@ -226,10 +226,11 @@ export default class LocalProjectManager extends BaseProjectManager {
       if (matched) {
         dest = dest.replace(matchRule, getCount(matched))
       } else {
-        const copiedName = toDir.replace(fromName, `${fromName}-copy1`)
-        dest = fromIsFile ? `${toDir}/${fromName}-copy1${fromExt}` : copiedName
+        const copiedName = toDir.replace(fromName, `${fromName} copy1`)
+        dest = fromIsFile ? `${toDir}/${fromName} copy1${fromExt}` : copiedName
       }
     }
+
     try {
       await this.copy(from, dest)
     } catch (e) {


### PR DESCRIPTION
- [x] fix: set README.md as defaulted open file
- [x] fix: duplicated file causes loading tree data error 
- [x] fix: keep the target folder  in an open status after copying a file or cutting a file
- [x] fix: delete file failed
    - [ ] change:  use shell.trashItem  to move a file to recycle bin instead of trash package
    - [ ] reason:   trash command delete folder failed in windows operating system

