### PR TITLE
fix: right-click same item of filtree causes contenxtmenu disappear

### DIFF
--- a/packages/filetree/src/index.js
+++ b/packages/filetree/src/index.js
@@ -183,6 +183,7 @@ const FileTree = forwardRef(({ projectManager, onSelect, move, copy, initialPath
     }
 
     const handleEmptyTreeContextMenu = (event) => {
+      if (event.target.className.includes('react-contexify')) return
       setIsBlankAreaRightClick(true)
       setRightClikNode(treeData[0])
       removePersist()


### PR DESCRIPTION
- [x] fix: repeat right-click one item of filetree cause context-menu disappear
