### PR TITLE
fix: hiden edit button on share status

### DIFF
--- a/packages/code-editor/src/customTabs/Markdown/index.js
+++ b/packages/code-editor/src/customTabs/Markdown/index.js
@@ -121,6 +121,7 @@ export default class Markdown extends Component {
   }
 
   renderHovers = () => {
+    if (!modelSessionManager.projectManager.userOwnProject) return
     if (!this.display || !this.filePath.endsWith(':/README.md')) {
       return (
         <div style={{


### PR DESCRIPTION
- [x] fix: hide the edit button when browsing a shared project