### PR TITLE
Port components from reactstrap with Tailwind CSS

### DIFF
--- a/packages/ui-components/src/Card/TableCardRow.js
+++ b/packages/ui-components/src/Card/TableCardRow.js
@@ -1,8 +1,6 @@
 import React from 'react'
-import {
-  Badge,
-  UncontrolledTooltip
-} from 'reactstrap'
+import { UncontrolledTooltip } from 'reactstrap'
+import Badge from '../ported/Badge'
 
 export default function TableCardRow ({
   name,

--- a/packages/ui-components/src/index.js
+++ b/packages/ui-components/src/index.js
@@ -58,4 +58,6 @@ export {
   Media,
 } from 'reactstrap'
 
+export * from './ported'
+
 import './styles/index.scss'

--- a/packages/ui-components/src/inputs/DropdownInput.js
+++ b/packages/ui-components/src/inputs/DropdownInput.js
@@ -10,9 +10,9 @@ import {
   Dropdown,
   DropdownToggle,
   DropdownMenu,
-  DropdownItem,
-  Badge
+  DropdownItem
 } from 'reactstrap'
+import Badge from '../ported/Badge'
 import { utils } from '@obsidians/sdk'
 
 export default class DropdownInput extends PureComponent {

--- a/packages/ui-components/src/ported/Badge.js
+++ b/packages/ui-components/src/ported/Badge.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+
+const Badge = ({
+  className,
+  color = 'secondary',
+  pill = false,
+  ...attributes
+}) => {
+  const classes = classNames(
+    className,
+    'inline py-[0.25em] px-[0.4em] text-[75%] font-bold',
+    'leading-none text-center whitespace-nowrap align-baseline',
+    'rounded transition-colors transition-shadow duration-150 ease-in-out',
+    'print:border-1 print:border-black motion-reduce:transition-none',
+    'hover:no-underline empty:hidden',
+    `bg-badge-${color} text-badge-${color}`,
+    pill ? 'px-[0.6em] rounded-full' : false
+  )
+
+  return <span {...attributes} className={classes} />
+}
+
+Badge.propTypes = {
+  color: PropTypes.string,
+  pill: PropTypes.bool,
+  children: PropTypes.node,
+  className: PropTypes.string
+}
+
+export default Badge
+
+// DO NOT REMOVE FOLLOWING LINES!
+// bg-badge-primary
+// bg-badge-secondary
+// bg-badge-success
+// bg-badge-info
+// bg-badge-warning
+// bg-badge-danger
+// bg-badge-light
+// bg-badge-dark
+// text-badge-primary
+// text-badge-secondary
+// text-badge-success
+// text-badge-info
+// text-badge-warning
+// text-badge-danger
+// text-badge-light
+// text-badge-dark

--- a/packages/ui-components/src/ported/Container.js
+++ b/packages/ui-components/src/ported/Container.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+
+const Container = ({ className, ...attributes }) => {
+  return (
+    <div
+      {...attributes}
+      className={classNames(
+        className,
+        'w-full px-[15px] mx-auto print:m-w-[992px]',
+        'sm:max-w-screen-sm md:max-w-screen-md lg:max-w-screen-lg xl:max-w-screen-xl',
+      )}
+    />
+  )
+}
+
+Container.propTypes = {
+  className: PropTypes.string
+}
+
+export default Container

--- a/packages/ui-components/src/ported/Jumbotron.js
+++ b/packages/ui-components/src/ported/Jumbotron.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+
+const Jumbotron = ({ className, ...attributes }) => {
+  return (
+    <div
+      {...attributes}
+      className={classNames(className, 'py-8 sm:py-16 px-4 sm:px-8 mb-8 bg-jumbotron rounded-1.2')}
+    />
+  )
+}
+
+Jumbotron.propTypes = {
+  className: PropTypes.string
+}
+
+export default Jumbotron

--- a/packages/ui-components/src/ported/index.js
+++ b/packages/ui-components/src/ported/index.js
@@ -1,0 +1,2 @@
+// This file re-exports all components ported from reactstrap.
+export { default as Jumbotron } from './Jumbotron'

--- a/packages/ui-components/src/ported/index.js
+++ b/packages/ui-components/src/ported/index.js
@@ -1,2 +1,3 @@
 // This file re-exports all components ported from reactstrap.
 export { default as Jumbotron } from './Jumbotron'
+export { default as Container } from './Container'

--- a/packages/ui-components/src/ported/index.js
+++ b/packages/ui-components/src/ported/index.js
@@ -1,3 +1,4 @@
 // This file re-exports all components ported from reactstrap.
 export { default as Jumbotron } from './Jumbotron'
 export { default as Container } from './Container'
+export { default as Badge } from './Badge'


### PR DESCRIPTION
This PR re-implements components from [reactstrap](https://reactstrap.github.io) v8 with Tailwind CSS.

This PR is a companion of https://github.com/ObsidianLabs/Black-IDE/pull/86. So, they should be merged together when tests are done.